### PR TITLE
Use route constants for admin paths

### DIFF
--- a/src/javascript/AdminPanel/AdminPanel.routes.jsx
+++ b/src/javascript/AdminPanel/AdminPanel.routes.jsx
@@ -9,8 +9,8 @@ export const registerRoutes = () => {
         targets: ['administration-sites:10'],
         icon: <DefaultEntry/>,
         label: 'translationExportImport:translationExportImport.label',
-        path: `${constants.DEFAULT_ROUTE}*`, // Catch everything and let the app handle routing logic
-        defaultPath: constants.DEFAULT_ROUTE,
+        path: `${constants.ROUTE}*`, // Catch everything and let the app handle routing logic
+        defaultPath: constants.ROUTE_DEFAULT_PATH,
         isSelectable: true,
         render: v => <Suspense fallback="loading ..."><AdminPanel match={v.match}/></Suspense>
     });


### PR DESCRIPTION
## Summary
- align admin route configuration with new constant names

## Testing
- `npx eslint --format json --ext js,jsx src/javascript/AdminPanel/AdminPanel.routes.jsx`
- `node node_modules/.bin/jest` *(fails: Cannot find module '/workspace/translationExportImport/node_modules/.bin/jest')*


------
https://chatgpt.com/codex/tasks/task_b_689373377fbc832ca92992612197ae2a