### PR TITLE
Add export utilities and styles

### DIFF
--- a/src/javascript/AdminPanel/ExportContent.component.scss
+++ b/src/javascript/AdminPanel/ExportContent.component.scss
@@ -1,0 +1,44 @@
+.container {
+    display: flex;
+    gap: 20px;
+    margin: 20px;
+}
+
+.leftPanel {
+    flex: 1;
+    max-width: 300px;
+}
+
+.rightPanel {
+    flex: 1;
+}
+
+.heading {
+    margin-bottom: 8px;
+}
+
+.customDropdown {
+    width: 100%;
+    margin-bottom: 16px;
+}
+
+.separatorInput {
+    margin-top: 16px;
+}
+
+.scrollableProperties {
+    max-height: 400px;
+    overflow: auto;
+    border: 1px solid #dedede;
+    padding: 8px;
+}
+
+.propertyItem {
+    display: flex;
+    align-items: center;
+    margin-bottom: 4px;
+}
+
+.separatorLine {
+    margin: 8px 0;
+}

--- a/src/javascript/AdminPanel/ExportContent.utils.js
+++ b/src/javascript/AdminPanel/ExportContent.utils.js
@@ -1,0 +1,31 @@
+export const exportCSVFile = (items, fileName, headers, separator = ',') => {
+    if (!items || items.length === 0 || !headers) {
+        // Nothing to export
+        return;
+    }
+
+    const headerRow = headers.join(separator);
+    const rows = items.map(row =>
+        headers.map(h => `"${String(row[h] ?? '').replace(/"/g, '""')}"`).join(separator)
+    );
+    const csvContent = [headerRow, ...rows].join('\n');
+
+    const blob = new Blob([csvContent], {type: 'text/csv;charset=utf-8;'});
+    const link = document.createElement('a');
+    link.href = URL.createObjectURL(blob);
+    link.setAttribute('download', `${fileName}.csv`);
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+};
+
+export const exportJSONFile = (data, fileName) => {
+    const jsonString = JSON.stringify(data, null, 2);
+    const blob = new Blob([jsonString], {type: 'application/json;charset=utf-8;'});
+    const link = document.createElement('a');
+    link.href = URL.createObjectURL(blob);
+    link.setAttribute('download', `${fileName}.json`);
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+};

--- a/src/javascript/ExportContentToCsv/ExportContent.utils.js
+++ b/src/javascript/ExportContentToCsv/ExportContent.utils.js
@@ -1,0 +1,8 @@
+export const extractAndFormatContentTypeData = data => {
+    const nodes = data?.jcr?.nodeTypes?.nodes || [];
+    return nodes.map(n => ({
+        label: n.displayName || n.name,
+        value: n.name,
+        iconStart: n.icon
+    }));
+};


### PR DESCRIPTION
## Summary
- style admin export panel
- add CSV/JSON export helpers
- expose formatter for content type data

## Testing
- `./node_modules/.bin/eslint --ext js,jsx .`
- `npx jest` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*


------
https://chatgpt.com/codex/tasks/task_b_689376c960ac832ca300b63690fe56ca