### PR TITLE
feat: add translations for admin panel

### DIFF
--- a/src/main/resources/javascript/locales/en.json
+++ b/src/main/resources/javascript/locales/en.json
@@ -1,6 +1,24 @@
 {
   "translationExportImport": {
-    "label" : "Translation Export Import",
-    "hello" : "Hello"
+    "label": {
+      "loadingContentTypes": "Loading content types...",
+      "previewTitle": "Preview",
+      "previewCancel": "Cancel",
+      "previewDownload": "Download",
+      "header": "Export content for {{siteInfo}}",
+      "exporting": "Exporting...",
+      "exportToCSV": "Export to CSV",
+      "exportToJSON": "Export to JSON",
+      "selectLanguage": "Select language",
+      "selectPlaceholder": "Select an option",
+      "selectContentType": "Select content type",
+      "exportFormat": "Export format",
+      "separator": "Separator",
+      "separatorPlaceholder": "Select a separator",
+      "selectProperties": "Select properties",
+      "loadingProperties": "Loading properties...",
+      "selectAll": "Select all",
+      "noProperties": "No properties available"
+    }
   }
 }

--- a/src/main/resources/javascript/locales/fr.json
+++ b/src/main/resources/javascript/locales/fr.json
@@ -1,6 +1,24 @@
 {
   "translationExportImport": {
-    "label" : "Export et import de traductions",
-    "hello" : "Bonjour"
+    "label": {
+      "loadingContentTypes": "Chargement des types de contenu...",
+      "previewTitle": "Aperçu",
+      "previewCancel": "Annuler",
+      "previewDownload": "Télécharger",
+      "header": "Exporter le contenu pour {{siteInfo}}",
+      "exporting": "Export en cours...",
+      "exportToCSV": "Exporter en CSV",
+      "exportToJSON": "Exporter en JSON",
+      "selectLanguage": "Sélectionner la langue",
+      "selectPlaceholder": "Sélectionner une option",
+      "selectContentType": "Sélectionner un type de contenu",
+      "exportFormat": "Format d'export",
+      "separator": "Séparateur",
+      "separatorPlaceholder": "Sélectionner un séparateur",
+      "selectProperties": "Sélectionner des propriétés",
+      "loadingProperties": "Chargement des propriétés...",
+      "selectAll": "Tout sélectionner",
+      "noProperties": "Aucune propriété disponible"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add English and French translations for all AdminPanel labels

## Testing
- `npm run lint`
- `npm test` *(fails: env-cmd not found)*

------
https://chatgpt.com/codex/tasks/task_b_68937890e210832ca670bac7e00da2e3