### PR TITLE
Validate export response and improve error handling

### DIFF
--- a/src/javascript/AdminPanel/ExportPanel.jsx
+++ b/src/javascript/AdminPanel/ExportPanel.jsx
@@ -212,15 +212,33 @@ export const ExportPanel = () => {
 
         queryPromise
             .then(response => {
+                if (response?.errors) {
+                    log.error('GraphQL errors fetching content for export:', response.errors);
+                    notify('error', t('label.exportError'));
+                    return;
+                }
+
                 if (exportType === 'translations') {
-                    const nodes = response.data.jcr.nodeByPath.descendants.nodes;
+                    const nodes = response?.data?.jcr?.nodeByPath?.descendants?.nodes;
+
+                    if (!nodes) {
+                        notify('error', t('label.exportError'));
+                        return;
+                    }
+
                     setPendingExport({type: 'json', data: nodes});
                     setPreviewData(JSON.stringify(nodes, null, 2));
                     setIsPreviewOpen(true);
                     return;
                 }
 
-                const rootNode = response.data.jcr.result;
+                const rootNode = response?.data?.jcr?.result;
+
+                if (!rootNode) {
+                    notify('error', t('label.exportError'));
+                    return;
+                }
+
                 const descendants = rootNode.descendants.nodes;
 
                 if (exportFormat === 'csv') {
@@ -269,7 +287,7 @@ export const ExportPanel = () => {
             })
             .catch(err => {
                 log.error('Error fetching content for export:', err);
-                notify('error', `${filename}.${exportFormat}`);
+                notify('error', t('label.exportError'));
             })
             .finally(() => {
                 setIsExporting(false);

--- a/src/main/resources/javascript/locales/en.json
+++ b/src/main/resources/javascript/locales/en.json
@@ -26,7 +26,8 @@
       "uploadFile": "Upload JSON file",
       "importTranslations": "Import translations",
       "importButton": "Import",
-      "importSuccess": "Translations imported"
+      "importSuccess": "Translations imported",
+      "exportError": "Unable to export content"
     }
   }
 }

--- a/src/main/resources/javascript/locales/fr.json
+++ b/src/main/resources/javascript/locales/fr.json
@@ -26,7 +26,8 @@
       "uploadFile": "Téléverser le fichier JSON",
       "importTranslations": "Importer les traductions",
       "importButton": "Importer",
-      "importSuccess": "Traductions importées"
+      "importSuccess": "Traductions importées",
+      "exportError": "Impossible d'exporter le contenu"
     }
   }
 }


### PR DESCRIPTION
## Summary
- guard export response against missing data or GraphQL errors and notify user
- add localized `exportError` messages for failed exports

## Testing
- `npx jest` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*
- `yarn lint` *(fails: 10 errors)*

------
https://chatgpt.com/codex/tasks/task_b_68937fe4e200832ca8a8a1136e5c379d