### PR TITLE
feat: add landing panel for import/export

### DIFF
--- a/src/javascript/AdminPanel/AdminPanel.constants.jsx
+++ b/src/javascript/AdminPanel/AdminPanel.constants.jsx
@@ -1,5 +1,5 @@
 
 export default {
     ROUTE: '/translationExportImport',
-    ROUTE_DEFAULT_PATH: 'export'
+    ROUTE_DEFAULT_PATH: ''
 };

--- a/src/javascript/AdminPanel/AdminPanel.jsx
+++ b/src/javascript/AdminPanel/AdminPanel.jsx
@@ -1,12 +1,21 @@
 import React from 'react';
 import {Route, Switch, Redirect} from 'react-router';
+import PropTypes from 'prop-types';
 import {ExportPanel} from './ExportPanel';
 import {ImportPanel} from './ImportPanel';
+import {StartPanel} from './StartPanel';
 
 export const AdminPanel = ({match}) => (
     <Switch>
+        <Route exact path={match.path} component={StartPanel}/>
         <Route path={`${match.path}/import`} component={ImportPanel}/>
         <Route path={`${match.path}/export`} component={ExportPanel}/>
-        <Redirect to={`${match.path}/export`}/>
+        <Redirect to={match.path}/>
     </Switch>
 );
+
+AdminPanel.propTypes = {
+    match: PropTypes.shape({
+        path: PropTypes.string.isRequired
+    }).isRequired
+};

--- a/src/javascript/AdminPanel/StartPanel.jsx
+++ b/src/javascript/AdminPanel/StartPanel.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import {Button, Header} from '@jahia/moonstone';
+import {useTranslation} from 'react-i18next';
+import {useHistory} from 'react-router';
+import PropTypes from 'prop-types';
+
+export const StartPanel = ({match}) => {
+    const {t} = useTranslation('translationExportImport');
+    const history = useHistory();
+
+    const goTo = path => () => {
+        history.push(`${match.url}/${path}`);
+    };
+
+    return (
+        <>
+            <Header title={t('label.selectAction')}/>
+            <div style={{display: 'flex', gap: '1rem'}}>
+                <Button
+                    key="import"
+                    size="big"
+                    color="accent"
+                    label={t('label.importButton')}
+                    onClick={goTo('import')}
+                />
+                <Button
+                    key="export"
+                    size="big"
+                    color="accent"
+                    label={t('label.exportButton')}
+                    onClick={goTo('export')}
+                />
+            </div>
+        </>
+    );
+};
+
+StartPanel.propTypes = {
+    match: PropTypes.shape({
+        url: PropTypes.string.isRequired
+    }).isRequired
+};

--- a/src/main/resources/javascript/locales/en.json
+++ b/src/main/resources/javascript/locales/en.json
@@ -26,6 +26,8 @@
       "uploadFile": "Upload JSON file",
       "importTranslations": "Import translations",
       "importButton": "Import",
+      "exportButton": "Export",
+      "selectAction": "Select action",
       "importSuccess": "Translations imported",
       "exportError": "Unable to export content"
     }

--- a/src/main/resources/javascript/locales/fr.json
+++ b/src/main/resources/javascript/locales/fr.json
@@ -26,6 +26,8 @@
       "uploadFile": "Téléverser le fichier JSON",
       "importTranslations": "Importer les traductions",
       "importButton": "Importer",
+      "exportButton": "Exporter",
+      "selectAction": "Sélectionner une action",
       "importSuccess": "Traductions importées",
       "exportError": "Impossible d'exporter le contenu"
     }


### PR DESCRIPTION
## Summary
- add landing panel to choose between import and export actions
- update routes to show selection panel by default
- translate export button and action selection labels

## Testing
- `yarn test` *(fails: env-cmd not found)*
- `yarn add --dev jest env-cmd` *(fails: RequestError 403)*
- `yarn lint` *(fails: This package doesn't seem to be present in your lockfile; run "yarn install" to update the lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_689389241eb4832c8e96e028adff3009