### PR TITLE
Use site and language in translation export filenames

### DIFF
--- a/src/javascript/AdminPanel/ExportPanel.jsx
+++ b/src/javascript/AdminPanel/ExportPanel.jsx
@@ -228,7 +228,9 @@ export const ExportPanel = () => {
     const handleExport = () => {
         setIsExporting(true);
         const timestamp = new Date().toISOString().replace(/[:.-]/g, '_');
-        const filename = `${exportType === 'translations' ? 'translations' : selectedContentType}_${timestamp}`;
+        const filename = exportType === 'translations' ?
+            `${siteKey}_${selectedLanguage}_${timestamp}` :
+            `${selectedContentType}_${timestamp}`;
         setExportFilename(filename);
 
         let queryPromise;


### PR DESCRIPTION
## Summary
- Include site key and language in translation export filenames

## Testing
- `npx eslint src/javascript/AdminPanel/ExportPanel.jsx`
- `yarn test` *(fails: package not in lockfile)*
- `mvn -q test` *(fails: non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_b_6893bff55be0832c85d34fd3259488e7