### PR TITLE
Align import panel styling with export panel

### DIFF
--- a/src/javascript/AdminPanel/ExportContent.component.scss
+++ b/src/javascript/AdminPanel/ExportContent.component.scss
@@ -67,3 +67,12 @@ $font-family: 'Roboto', sans-serif;
         box-shadow: 0px 2px 5px rgba(0, 0, 0, 0.1);
     }
 }
+
+.fileInput {
+    border: 1px solid #cccccc;
+    border-radius: 4px;
+    padding: 8px;
+    background-color: #ffffff;
+    margin-bottom: 16px;
+    width: 100%;
+}

--- a/src/javascript/AdminPanel/ImportPanel.jsx
+++ b/src/javascript/AdminPanel/ImportPanel.jsx
@@ -4,6 +4,7 @@ import {Button, Header, Dropdown, Typography} from '@jahia/moonstone';
 import {useTranslation} from 'react-i18next';
 import {GetSiteLanguagesQuery} from '~/gql-queries/ExportTranslations.gql-queries';
 import {ApplyTranslationsMutation} from '~/gql-queries/ImportTranslations.gql-queries';
+import styles from './ExportContent.component.scss';
 
 export const ImportPanel = () => {
     const {t} = useTranslation('translationExportImport');
@@ -82,7 +83,7 @@ export const ImportPanel = () => {
     return (
         <>
             <Header
-                title={t('label.importTranslations')}
+                title={t('label.header', {siteInfo: siteKey})}
                 mainActions={[
                     <Button
                         key="importButton"
@@ -94,20 +95,28 @@ export const ImportPanel = () => {
                     />
                 ]}
             />
-            <div>
-                <Typography variant="heading">
-                    {t('label.uploadFile')}
-                </Typography>
-                <input type="file" accept="application/json" onChange={handleFileChange}/>
-                <Typography variant="heading">
-                    {t('label.selectLanguage')}
-                </Typography>
-                <Dropdown
-                    data={languages}
-                    value={selectedLanguage}
-                    placeholder={t('label.selectPlaceholder')}
-                    onChange={(e, item) => setSelectedLanguage(item.value)}
-                />
+            <div className={styles.container}>
+                <div className={styles.leftPanel}>
+                    <Typography variant="heading" className={styles.heading}>
+                        {t('label.uploadFile')}
+                    </Typography>
+                    <input
+                        accept="application/json"
+                        className={styles.fileInput}
+                        type="file"
+                        onChange={handleFileChange}
+                    />
+                    <Typography variant="heading" className={styles.heading}>
+                        {t('label.selectLanguage')}
+                    </Typography>
+                    <Dropdown
+                        data={languages}
+                        value={selectedLanguage}
+                        className={styles.customDropdown}
+                        placeholder={t('label.selectPlaceholder')}
+                        onChange={(e, item) => setSelectedLanguage(item.value)}
+                    />
+                </div>
             </div>
         </>
     );


### PR DESCRIPTION
## Summary
- Reuse export panel styles within import panel for consistent layout and dropdown appearance
- Add stylesheet class to style file upload field alongside dropdown

## Testing
- `npx eslint --ext js,jsx .`
- `npx jest` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*


------
https://chatgpt.com/codex/tasks/task_b_6893c8a97534832c8595c342322bfc7e