### PR TITLE
feat: add import report and reset form

### DIFF
--- a/src/main/resources/javascript/locales/en.json
+++ b/src/main/resources/javascript/locales/en.json
@@ -16,7 +16,13 @@
       "exportButton": "Export",
       "selectAction": "Select action",
       "importSuccess": "Translations imported",
-      "exportError": "Unable to export translations"
+      "importReport": "{{modified}} objects modified",
+      "importReportWithFails": "{{modified}} objects modified, {{failed}} failed",
+      "exportError": "Unable to export translations",
+      "path": "Content path",
+      "enterPathSuffix": "Enter content path suffix",
+      "enterPathSuffixHelp": "By default, export runs on all content with internationalized properties from the site root.",
+      "selectFolder": "Select Path"
     }
 
 }

--- a/src/main/resources/javascript/locales/fr.json
+++ b/src/main/resources/javascript/locales/fr.json
@@ -16,11 +16,12 @@
       "exportButton": "Exporter",
       "selectAction": "Sélectionner une action",
       "importSuccess": "Traductions importées",
+      "importReport": "{{modified}} objets modifiés",
+      "importReportWithFails": "{{modified}} objets modifiés, {{failed}} échecs",
       "exportError": "Impossible d'exporter les traductions",
       "path": "Chemin du contenu",
       "enterPathSuffix": "Entrez le suffixe du chemin de contenu",
-      "enterPathSuffixHelp": "Par défaut, l'export se fait sur tout le contenu présentant des propriétés internationalisés à partir de la racine du site.",
-      "selectFolder": "Select. Chemin"
+      "enterPathSuffixHelp": "Par défaut, l'export se fait sur tout le contenu présentant des propriétés internationalisées à partir de la racine du site.",
+      "selectFolder": "Sélectionner le chemin"
     }
-
 }


### PR DESCRIPTION
## Summary
- show import summary with counts of modified and failed items
- reset import form after applying translations
- align and extend i18n labels in English and French

## Testing
- `yarn lint`
- `yarn test` *(fails: env-cmd not found; installing env-cmd failed with 403)*

------
https://chatgpt.com/codex/tasks/task_b_689479ce50f0832c9bbda14d9a23355d