### PR TITLE
Add back button to translation import/export panels

### DIFF
--- a/src/javascript/AdminPanel/ExportPanel.jsx
+++ b/src/javascript/AdminPanel/ExportPanel.jsx
@@ -1,15 +1,19 @@
 import React, {useEffect, useState} from 'react';
 import {useLazyQuery} from '@apollo/client';
 import {GetSiteLanguagesQuery, FetchSiteInternationalizedContents} from '~/gql-queries/ExportTranslations.gql-queries';
-import {Button, Header, Dropdown, Typography, Input} from '@jahia/moonstone';
+import {Button, Header, Dropdown, Typography, Input, ArrowLeft} from '@jahia/moonstone';
 import {Dialog, DialogActions, DialogContent, DialogTitle} from '@material-ui/core';
 import styles from './ExportContent.component.scss';
 import {useTranslation} from 'react-i18next';
 import {exportJSONFile} from './Export.utils';
 import log from '~/log';
+import {useHistory, useRouteMatch} from 'react-router';
 
 export const ExportPanel = () => {
     const {t} = useTranslation('translationExportImport');
+    const history = useHistory();
+    const match = useRouteMatch();
+    const baseUrl = match.url.split('/').slice(0, -1).join('/');
     const [languages, setLanguages] = useState([]);
     const [selectedLanguage, setSelectedLanguage] = useState(window.contextJsParameters.uilang);
     const [isExporting, setIsExporting] = useState(false);
@@ -187,6 +191,13 @@ export const ExportPanel = () => {
             </Dialog>
             <Header
                 title={t('label.headerExport', {siteInfo: siteKey})}
+                backButton={(
+                    <Button
+                        icon={<ArrowLeft/>}
+                        label={t('label.backButton')}
+                        onClick={() => history.push(baseUrl)}
+                    />
+                )}
                 mainActions={[
                     <Button
                         key="exportButton"

--- a/src/javascript/AdminPanel/ImportPanel.jsx
+++ b/src/javascript/AdminPanel/ImportPanel.jsx
@@ -1,7 +1,8 @@
 import React, {useEffect, useState, useRef} from 'react';
 import {useLazyQuery, useMutation} from '@apollo/client';
-import {Button, Header, Dropdown, Typography} from '@jahia/moonstone';
+import {Button, Header, Dropdown, Typography, ArrowLeft} from '@jahia/moonstone';
 import {useTranslation} from 'react-i18next';
+import {useHistory, useRouteMatch} from 'react-router';
 import {GetSiteLanguagesQuery} from '~/gql-queries/ExportTranslations.gql-queries';
 import {UpdateContentMutation} from '~/gql-queries/ImportTranslations.gql-queries';
 import styles from './ExportContent.component.scss';
@@ -9,6 +10,9 @@ import {LoaderOverlay} from '~/DesignSystem/LoaderOverlay';
 
 export const ImportPanel = () => {
     const {t} = useTranslation('translationExportImport');
+    const history = useHistory();
+    const match = useRouteMatch();
+    const baseUrl = match.url.split('/').slice(0, -1).join('/');
     const [fileContent, setFileContent] = useState(null);
     const [languages, setLanguages] = useState([]);
     const defaultLanguage = window.contextJsParameters.uilang;
@@ -138,6 +142,13 @@ export const ImportPanel = () => {
             )}
             <Header
                 title={t('label.headerImport', {siteInfo: siteKey})}
+                backButton={(
+                    <Button
+                        icon={<ArrowLeft/>}
+                        label={t('label.backButton')}
+                        onClick={() => history.push(baseUrl)}
+                    />
+                )}
                 mainActions={[
                     <Button
                         key="importButton"

--- a/src/main/resources/javascript/locales/en.json
+++ b/src/main/resources/javascript/locales/en.json
@@ -15,6 +15,7 @@
     "importTranslations": "Import translations",
     "importButton": "Import",
     "exportButton": "Export",
+    "backButton": "Back",
     "selectAction": "Select an action",
     "importSuccess": "Translations imported",
     "importReport": "{{modified}} objects modified",

--- a/src/main/resources/javascript/locales/fr.json
+++ b/src/main/resources/javascript/locales/fr.json
@@ -15,6 +15,7 @@
       "importTranslations": "Importer les traductions",
       "importButton": "Importer",
       "exportButton": "Exporter",
+      "backButton": "Retour",
       "selectAction": "Sélectionner une action",
       "importSuccess": "Traductions importées",
       "importReport": "{{modified}} objets modifiés",


### PR DESCRIPTION
## Summary
- add back navigation button to import and export panels
- provide i18n labels for the new back button

## Testing
- `yarn test` *(fails: command not found: env-cmd)*

------
https://chatgpt.com/codex/tasks/task_b_6894d5932ec0832ca99ae9a3f43a9919