### PR TITLE
feat: improve import error reporting

### DIFF
--- a/src/javascript/AdminPanel/ImportPanel.jsx
+++ b/src/javascript/AdminPanel/ImportPanel.jsx
@@ -80,6 +80,7 @@ export const ImportPanel = () => {
 
         let modifiedCount = 0;
         let failedCount = 0;
+        const failedItems = [];
 
         /* eslint-disable no-await-in-loop */
         for (const {uuid, properties} of fileContent) {
@@ -107,14 +108,16 @@ export const ImportPanel = () => {
                 modifiedCount += 1;
             } catch (e) {
                 failedCount += 1;
-                console.error('Translation import error', e);
+                const reason = e?.message || e.toString();
+                failedItems.push({uuid, reason});
+                console.error('Translation import error', uuid, e);
             }
         }
         /* eslint-enable no-await-in-loop */
 
         setIsLoading(false);
 
-        setImportReport({modified: modifiedCount, failed: failedCount});
+        setImportReport({modified: modifiedCount, failed: failedCount, failedItems});
 
         if (window?.jahia?.ui?.notify) {
             const message = failedCount > 0 ?
@@ -183,9 +186,28 @@ export const ImportPanel = () => {
                         onChange={(e, item) => setSelectedLanguage(item.value)}
                     />
                     {importReport && (
-                        <Typography variant="body" className={styles.heading}>
-                            {t(importReport.failed > 0 ? 'label.importReportWithFails' : 'label.importReport', {modified: importReport.modified, failed: importReport.failed})}
-                        </Typography>
+                        <>
+                            <Typography variant="body" className={styles.heading}>
+                                {t(
+                                    importReport.failed > 0 ? 'label.importReportWithFails' : 'label.importReport',
+                                    {modified: importReport.modified, failed: importReport.failed}
+                                )}
+                            </Typography>
+                            {importReport.failed > 0 && (
+                                <>
+                                    <Typography variant="body" className={styles.heading}>
+                                        {t('label.importFailedItems')}
+                                    </Typography>
+                                    <ul>
+                                        {importReport.failedItems.map(item => (
+                                            <li key={item.uuid}>
+                                                <Typography variant="body">{`${item.uuid}: ${item.reason}`}</Typography>
+                                            </li>
+                                        ))}
+                                    </ul>
+                                </>
+                            )}
+                        </>
                     )}
                 </div>
             </div>

--- a/src/main/resources/javascript/locales/en.json
+++ b/src/main/resources/javascript/locales/en.json
@@ -20,6 +20,7 @@
     "importSuccess": "Translations imported",
     "importReport": "{{modified}} objects modified",
     "importReportWithFails": "{{modified}} objects modified, {{failed}} failed",
+    "importFailedItems": "Failed imports:",
     "exportError": "Unable to export translations",
     "path": "Content path",
     "enterPathSuffix": "Enter content path suffix",

--- a/src/main/resources/javascript/locales/fr.json
+++ b/src/main/resources/javascript/locales/fr.json
@@ -20,6 +20,7 @@
       "importSuccess": "Traductions importées",
       "importReport": "{{modified}} objets modifiés",
       "importReportWithFails": "{{modified}} objets modifiés, {{failed}} échecs",
+      "importFailedItems": "Échecs d'import :",
       "exportError": "Impossible d'exporter les traductions",
       "path": "Chemin du contenu",
       "enterPathSuffix": "Entrez le suffixe du chemin de contenu",


### PR DESCRIPTION
## Summary
- capture and display detailed import errors by uuid
- add translation keys for reporting failed imports

## Testing
- `./node_modules/.bin/eslint --ext js,jsx .`
- `npx jest` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*

------
https://chatgpt.com/codex/tasks/task_b_6894e5a02a18832caa4e622af4100c2f