### PR TITLE
Refactor translation export/import property format

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -57,15 +57,15 @@ The build uses the `frontend-maven-plugin` to install Node and Yarn, install dep
 
 #### JSON format
 
-The import process expects an array of objects where each object defines a node `uuid` and a list of `properties`. Each property contains a `name` and either a `value` or a list of `values`:
+The import process expects an array of objects where each object defines a node `uuid` and a list of `properties`. Each property object maps property names directly to their values. Multi-valued properties use arrays:
 
 ```json
 [
   {
     "uuid": "xxxx-xxxx-xxxx-xxxx",
     "properties": [
-      {"name": "jcr:title", "value": "Hello"},
-      {"name": "jcr:keywords", "values": ["one", "two"]}
+      {"jcr:title": "Hello"},
+      {"jcr:keywords": ["one", "two"]}
     ]
   }
 ]

--- a/src/javascript/AdminPanel/ExportPanel.jsx
+++ b/src/javascript/AdminPanel/ExportPanel.jsx
@@ -74,21 +74,18 @@ export const ExportPanel = () => {
                 }
 
                 if (Array.isArray(properties)) {
-                    const sanitizedProps = properties
-                        .map(({__typename: propTypename, value, values, ...propRest}) => {
-                            const prop = {...propRest};
+                    const sanitizedProps = properties.reduce((acc, {__typename: _, name, value, values}) => {
+                        const hasSingleValue = value !== undefined && value !== null && value !== '';
+                        const hasMultipleValues = Array.isArray(values) && values.length > 0;
 
-                            if (value !== undefined && value !== null && value !== '') {
-                                prop.value = value;
-                            }
+                        if (hasSingleValue) {
+                            acc.push({[name]: value});
+                        } else if (hasMultipleValues) {
+                            acc.push({[name]: values});
+                        }
 
-                            if (Array.isArray(values) && values.length > 0) {
-                                prop.values = values;
-                            }
-
-                            return Object.keys(prop).length > 1 ? prop : null;
-                        })
-                        .filter(Boolean);
+                        return acc;
+                    }, []);
 
                     if (sanitizedProps.length > 0) {
                         sanitizedNode.properties = sanitizedProps;

--- a/src/javascript/AdminPanel/ImportPanel.jsx
+++ b/src/javascript/AdminPanel/ImportPanel.jsx
@@ -86,17 +86,19 @@ export const ImportPanel = () => {
         for (const {uuid, properties} of fileContent) {
             const propertiesInput = [];
             for (const propertyObj of properties) {
-                const propertyInput = {name: propertyObj.name, language: selectedLanguage};
-                if (Array.isArray(propertyObj.values)) {
-                    propertyInput.values = propertyObj.values;
-                } else if (typeof propertyObj.value === 'string') {
-                    propertyInput.value = propertyObj.value;
-                } else {
-                    console.warn('Unsupported property format', propertyObj);
-                    continue;
-                }
+                for (const [propName, propValue] of Object.entries(propertyObj)) {
+                    const propertyInput = {name: propName, language: selectedLanguage};
+                    if (Array.isArray(propValue)) {
+                        propertyInput.values = propValue;
+                    } else if (typeof propValue === 'string') {
+                        propertyInput.value = propValue;
+                    } else {
+                        console.warn('Unsupported property format', propertyObj);
+                        continue;
+                    }
 
-                propertiesInput.push(propertyInput);
+                    propertiesInput.push(propertyInput);
+                }
             }
 
             if (propertiesInput.length === 0) {


### PR DESCRIPTION
## Summary
- export translation properties as key-value pairs instead of name/value objects
- update import logic to handle new export format
- document new JSON structure for imports

## Testing
- `yarn lint`
- `yarn test` *(fails: command not found env-cmd)*
- `npx jest` *(fails: 403 Forbidden fetching package)*

------
https://chatgpt.com/codex/tasks/task_b_689c76dec3ec832c9af8767515175e9f