### PR TITLE
Export properties as single object in translation export

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -57,15 +57,17 @@ The build uses the `frontend-maven-plugin` to install Node and Yarn, install dep
 
 #### JSON format
 
-The import process expects an array of objects where each object defines a node `uuid` and a list of `properties`. Each property object maps property names directly to their values. Multi-valued properties use arrays:
+The import process expects an array of objects where each object defines a node `uuid` and a list of `properties`. Each `properties` array contains a single object that maps property names directly to their values. Multi-valued properties use arrays:
 
 ```json
 [
   {
     "uuid": "xxxx-xxxx-xxxx-xxxx",
     "properties": [
-      {"jcr:title": "Hello"},
-      {"jcr:keywords": ["one", "two"]}
+      {
+        "jcr:title": "Hello",
+        "jcr:keywords": ["one", "two"]
+      }
     ]
   }
 ]

--- a/src/javascript/AdminPanel/ExportPanel.jsx
+++ b/src/javascript/AdminPanel/ExportPanel.jsx
@@ -79,16 +79,16 @@ export const ExportPanel = () => {
                         const hasMultipleValues = Array.isArray(values) && values.length > 0;
 
                         if (hasSingleValue) {
-                            acc.push({[name]: value});
+                            acc[name] = value;
                         } else if (hasMultipleValues) {
-                            acc.push({[name]: values});
+                            acc[name] = values;
                         }
 
                         return acc;
-                    }, []);
+                    }, {});
 
-                    if (sanitizedProps.length > 0) {
-                        sanitizedNode.properties = sanitizedProps;
+                    if (Object.keys(sanitizedProps).length > 0) {
+                        sanitizedNode.properties = [sanitizedProps];
                     }
                 }
 


### PR DESCRIPTION
## Summary
- Collapse exported node properties into a single object so imports see grouped fields
- Document new JSON structure for properties

## Testing
- `yarn lint` *(fails: This package doesn't seem to be present in your lockfile; run "yarn install" to update the lockfile)*
- `yarn test` *(fails: This package doesn't seem to be present in your lockfile; run "yarn install" to update the lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_689c78ff0900832c8d99c29e9fc71b50